### PR TITLE
Dual package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## [Unreleased]
+### Changed
+- Changed the package format from CommonJS (CJS) only to a dual package supporting both CommonJS and ES Modules (ESM).
 
 ## [0.5.0] - 2023-09-10
 ### Added

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -99,7 +99,7 @@ export default tseslint.config(
 		},
 	},
 	{
-		files: ["**/*.js", "**/*.mjs"],
+		files: ["**/*.js", "**/*.mjs", "**/*.cjs"],
 		...tseslint.configs.disableTypeChecked,
 	},
 	{

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@stylistic/eslint-plugin": "^2.9.0",
         "eslint": "^9.13.0",
         "rollup": "^4.24.0",
+        "tsconfig-to-dual-package": "^1.2.0",
         "tslib": "^2.8.0",
         "typedoc": "^0.26.10",
         "typedoc-plugin-markdown": "^4.2.9",
@@ -2156,6 +2157,22 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-tsconfig": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/resolve-tsconfig/-/resolve-tsconfig-1.3.0.tgz",
+      "integrity": "sha512-Ba5mo3soshb2CnIcNFz75F/80H/2eMVxrlmdgoSDNH7Lr6UAoT3BvxNtc7+VXqKSBlC0SJk2qSXOTcy0/p7cFw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16",
+        "pnpm": ">=7"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/skarab42"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -2441,6 +2458,24 @@
       },
       "peerDependencies": {
         "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/tsconfig-to-dual-package": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-to-dual-package/-/tsconfig-to-dual-package-1.2.0.tgz",
+      "integrity": "sha512-UtMinqTLfWr9fX6KidLsEcCJoA/jSLPIS00ohpQybMSxA3LlJCRf2DsGPw4AJJ8AP4FOHfbQJFJ5XgLoL7RoLw==",
+      "dev": true,
+      "dependencies": {
+        "resolve-tsconfig": "^1.3.0"
+      },
+      "bin": {
+        "tsconfig-to-dual-package": "bin/cmd.mjs"
+      },
+      "engines": {
+        "node": ">=18.3.0 || >=16.17.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.0.0"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -5,14 +5,29 @@
   "directories": {
     "doc": "docs"
   },
-  "main": "lib/index.js",
+  "type": "module",
+  "main": "./lib/cjs/index.js",
+  "module": "./lib/esm/index.js",
+  "types": "./lib/esm/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./lib/esm/index.d.ts",
+        "default": "./lib/esm/index.js"
+      },
+      "require": {
+        "types": "./lib/cjs/index.d.ts",
+        "default": "./lib/cjs/index.js"
+      }
+    }
+  },
   "files": [
     "lib",
     "dist"
   ],
   "scripts": {
     "build": "npm run build:lib && npm run build:dist",
-    "build:lib": "tsc",
+    "build:lib": "tsc -p tsconfig.esm.json && tsc -p tsconfig.cjs.json && tsconfig-to-dual-package tsconfig.esm.json tsconfig.cjs.json",
     "build:dist": "mkdir -p dist && rollup -c",
     "build:doc": "typedoc",
     "clean": "rm -r lib dist",
@@ -36,6 +51,7 @@
     "@stylistic/eslint-plugin": "^2.9.0",
     "eslint": "^9.13.0",
     "rollup": "^4.24.0",
+    "tsconfig-to-dual-package": "^1.2.0",
     "tslib": "^2.8.0",
     "typedoc": "^0.26.10",
     "typedoc-plugin-markdown": "^4.2.9",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -29,13 +29,7 @@ const options = {
 		},
 	],
 	plugins: [
-		typescript({
-			compilerOptions: {
-				module: "ESNext",
-				declaration: false,
-				outDir: undefined,
-			},
-		}),
+		typescript({}),
 	],
 };
 

--- a/samples/glyphwiki_buhin.js
+++ b/samples/glyphwiki_buhin.js
@@ -1,5 +1,7 @@
 // This code is licensed under CC0
 
+/* global fetch, console */
+
 import { Kage, Polygons, Buhin } from "@kurgm/kage-engine";
 
 // Replace the body of this function as necessary with the code that retrieves

--- a/samples/sample.js
+++ b/samples/sample.js
@@ -1,4 +1,6 @@
-var { Kage, Polygons } = require("..");
+/* global console */
+
+import { Kage, Polygons } from "@kurgm/kage-engine";
 
 var kage = new Kage();
 var polygons = new Polygons();

--- a/src/kage.ts
+++ b/src/kage.ts
@@ -1,7 +1,7 @@
-import { Buhin } from "./buhin";
-import { Polygons } from "./polygons";
-import { stretch, Stroke } from "./stroke";
-import { KShotai, Font, select as selectFont } from "./font";
+import { Buhin } from "./buhin.js";
+import { Polygons } from "./polygons.js";
+import { stretch, Stroke } from "./stroke.js";
+import { KShotai, Font, select as selectFont } from "./font/index.js";
 
 /**
  * The entry point for KAGE engine (Kanji-glyph Automatic Generating Engine).

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
-/* eslint-disable */
+/* global console */
 
-const { Kage, Polygons } = require("../");
+import { Kage, Polygons } from "@kurgm/kage-engine";
 
 /**
  * @param {Record<string, string>} buhins

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "CommonJS",
+    "declaration": true,
+    "outDir": "./lib/cjs/"
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "declaration": true,
+    "outDir": "./lib/esm/"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -39,6 +39,7 @@
     // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
     // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
     // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
@@ -54,12 +55,11 @@
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "./lib/",                                  /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "importsNotUsedAsValues": "remove",               /* Specify emit/checking behavior for imports that are only used for types. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
     // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
     // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
@@ -71,11 +71,11 @@
     // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
-    // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
 
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
     "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
@@ -84,10 +84,11 @@
     /* Type Checking */
     "strict": true,                                      /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": false,                        /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
     // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
     "strictPropertyInitialization": false,               /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
     // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
     // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
     // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,7 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
+    "module": "ESNext",                                  /* Specify what module code is generated. */
     "rootDir": "./src/",                                 /* Specify the root folder within your source files. */
     // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
@@ -50,14 +50,14 @@
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
 
     /* Emit */
-    "declaration": true,                                 /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./lib/",                                  /* Specify an output folder for all emitted files. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
     // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */


### PR DESCRIPTION
Changed the package format from CommonJS (CJS) only to a dual package supporting both CommonJS and ES Modules (ESM).

パッケージ形式をCommonJS（CJS）のみから、CommonJSとESモジュール（ESM）の両方をサポートするデュアルパッケージに変更しました。